### PR TITLE
DRYD-1217: Disable archaeological site in bonsai

### DIFF
--- a/src/plugins/recordTypes/index.js
+++ b/src/plugins/recordTypes/index.js
@@ -4,6 +4,7 @@ import conservation from './conservation';
 import exhibition from './exhibition';
 import iterationreport from './iterationreport';
 import objectexit from './objectexit';
+import place from './place';
 
 export default [
   collectionobject,
@@ -12,4 +13,5 @@ export default [
   exhibition,
   iterationreport,
   objectexit,
+  place,
 ];

--- a/src/plugins/recordTypes/place/index.js
+++ b/src/plugins/recordTypes/place/index.js
@@ -1,0 +1,9 @@
+import vocabularies from './vocabularies';
+
+export default () => ({
+  recordTypes: {
+    place: {
+      vocabularies,
+    },
+  },
+});

--- a/src/plugins/recordTypes/place/vocabularies.js
+++ b/src/plugins/recordTypes/place/vocabularies.js
@@ -1,0 +1,5 @@
+export default {
+  archaeological: {
+    disabled: true,
+  },
+};


### PR DESCRIPTION
**What does this do?**
Disables the archaeological site place authority 

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1217

The archaeological site is only needed for core and anthro, so it's being disabled in other profiles.

**How should this be tested? Do these changes have associated tests?**
* Build cspace with the bonsai profile enabled
* Run the devserver
* Verify that the archaeological site is not visible when trying to create a place authority

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter tested against a local instance