### PR TITLE
Add fieldCollectionPlaces

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -489,7 +489,9 @@ const template = (configContext) => {
               <Field name="fieldCollectionMethod" />
             </Field>
 
-            <Field name="fieldCollectionPlace" />
+            <Field name="fieldCollectionPlaces">
+              <Field name="fieldCollectionPlace" />
+            </Field>
 
             <Field name="fieldCollectionSources">
               <Field name="fieldCollectionSource" />


### PR DESCRIPTION
**What does this do?**
Adds fieldCollectionPlaces to collectionobject default form

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1395

This allows the fieldCollectionPlace field to be a repeatable input.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver
* Create a collectionobject
* See that the Field collection place is a repeating input

**Dependencies for merging? Releasing to production?**
Requires the cspace-ui and application changes to display and save correctly

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
@mikejritter only ran npm lint