### PR TITLE
DRYD-1770: Add production agent verbatim

### DIFF
--- a/src/plugins/recordTypes/collectionobject/forms/default.jsx
+++ b/src/plugins/recordTypes/collectionobject/forms/default.jsx
@@ -305,6 +305,10 @@ const template = (configContext) => {
               </Field>
             </Field>
 
+            <Field name="objectProductionAgents">
+              <Field name="objectProductionAgent" />
+            </Field>
+
             <Field name="objectProductionNote" />
           </Col>
         </Row>


### PR DESCRIPTION
**What does this do?**
Adds `objectProductionAgents/objectProductionAgent` to the default template for CollectionObjects.

**Why are we doing this? (with JIRA link)**
Jira: https://collectionspace.atlassian.net/browse/DRYD-1770

This repeating field was requested to be added to assist with migrations. The Bonsai profile overrides the default template, so we're adding it here for completeness.

**How should this be tested? Do these changes have associated tests?**
* Run the devserver, e.g. `npm run devserver --back-end=https://bonsai.dev.collectionspace.org`
* Go to create a collection object
* Go to the 'Production' panel
* See 'Object production agents' visible

**Dependencies for merging? Releasing to production?**
None

**Has the application documentation been updated for these changes?**
No

**Did someone actually run this code to verify it works?**
No, I will test against bonsai.dev shortly.